### PR TITLE
Fix impersonation redirect

### DIFF
--- a/app/Http/Livewire/Galaxy/Users/Show.php
+++ b/app/Http/Livewire/Galaxy/Users/Show.php
@@ -63,7 +63,7 @@ class Show extends Component
         session(['after_impersonation' => route('galaxy.users.show', $this->user)]);
         auth()->user()->impersonate($this->user);
 
-        return redirect()->to('/my/settings');
+        return redirect()->to('/dashboard');
     }
 
     public function markAsVerified()


### PR DESCRIPTION
When impersonating a user from the details page, the redirect goes to a `404`