### PR TITLE
Flare bugs

### DIFF
--- a/app/Http/Livewire/App/Orders/Show.php
+++ b/app/Http/Livewire/App/Orders/Show.php
@@ -14,16 +14,16 @@ class Show extends Component
 
     public $page;
 
-    public function mount($page = 'payment')
+    public function mount($page = null)
     {
         $this->authorize('view', $this->order);
 
         if ($this->order->user_id !== auth()->id()) {
             $this->page = 'tickets';
-        } elseif ($this->order->isPaid()) {
+        } elseif ($this->order->isPaid() && $page === null) {
             $this->page = 'tickets';
         } else {
-            $this->page = $page;
+            $this->page = 'payment';
         }
     }
 

--- a/app/Http/Livewire/App/Orders/Tickets.php
+++ b/app/Http/Livewire/App/Orders/Tickets.php
@@ -49,8 +49,6 @@ class Tickets extends Component
 
     public $ticketsView = 'grid';
 
-    public $updateEmail = null;
-
     protected $listeners = [
         'refresh' => '$refresh',
         'loadNext' => 'loadNext',
@@ -203,6 +201,8 @@ class Tickets extends Component
 
     public function saveTicket()
     {
+        // $this->validate();
+
         $newUser = false;
         $sendNotification = true;
 
@@ -211,9 +211,9 @@ class Tickets extends Component
             $sendNotification = false;
         }
 
-        if ($this->editingTicket->user_id === null || $this->updateEmail === false) {
+        if ($this->editingTicket->user_id === null || $this->emailChanged === false) {
             $user = User::whereEmail($this->ticketholder['email'])->first();
-            if ($user === null && ! $this->updateEmail) {
+            if ($user === null && ! $this->emailChanged) {
                 $user = new User();
                 $user->email = $this->ticketholder['email'];
                 $user->password = Hash::make(Str::random(15));
@@ -221,9 +221,10 @@ class Tickets extends Component
             }
             $sendNotification = true;
         }
+
         $user->name = $this->ticketholder['name'];
         $user->pronouns = $this->ticketholder['pronouns'];
-        if ($this->updateEmail) {
+        if ($this->emailChanged) {
             $user->email = $this->ticketholder['email'];
         }
         $user->save();
@@ -238,7 +239,7 @@ class Tickets extends Component
         }
 
         $this->emit('refresh');
-        $this->reset('ticketholder', 'updateEmail', 'emailChanged');
+        $this->reset('ticketholder', 'emailChanged', 'emailChanged');
 
         $this->showTicketholderModal = false;
 

--- a/app/Http/Livewire/Galaxy/Orders.php
+++ b/app/Http/Livewire/Galaxy/Orders.php
@@ -40,7 +40,7 @@ class Orders extends Component
 
     public function updatedSelectPage($value)
     {
-        $this->selected = ($value) ? $this->rows->pluck('id')->map(fn ($id) => (string) $id)->toArray() : [];
+        $this->selected = ($value) ? $this->orders->pluck('id')->map(fn ($id) => (string) $id)->toArray() : [];
     }
 
     public function render()

--- a/app/Http/Livewire/Galaxy/Reservations.php
+++ b/app/Http/Livewire/Galaxy/Reservations.php
@@ -38,7 +38,7 @@ class Reservations extends Component
 
     public function updatedSelectPage($value)
     {
-        $this->selected = ($value) ? $this->rows->pluck('id')->map(fn ($id) => (string) $id)->toArray() : [];
+        $this->selected = ($value) ? $this->reservations->pluck('id')->map(fn ($id) => (string) $id)->toArray() : [];
     }
 
     public function updatedSelected($value)

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -186,10 +186,10 @@ class Order extends Model
                         'exp' => $method->card->exp_month.'/'.$method->card->exp_year,
                     ];
                 }
-            } elseif (Str::startsWith($this->transaction_id, '#')) {
+            } elseif (Str::startsWith($this->transaction_id, '#') || is_numeric($this->transaction_id)) {
                 return [
                     'type' => 'check',
-                    'check_number' => $this->transaction_id,
+                    'check_number' => Str::start($this->transaction_id, '#'),
                 ];
             } elseif (Str::startsWith($this->transaction_id, 'comped')) {
                 return [

--- a/resources/views/livewire/app/orders/payment.blade.php
+++ b/resources/views/livewire/app/orders/payment.blade.php
@@ -249,7 +249,7 @@
                             <p class="text-gray-900 dark:text-gray-200">Ending with {{ $transaction['last4'] }}</p>
                             <p>Expires {{ $transaction['exp'] }}</p>
                             @elseif ($transaction['type'] === 'check')
-                            <p class="text-gray-900">Number {{ $transaction['check_number'] }}</p>
+                            <p class="text-gray-900 dark:text-gray-200">Number {{ $transaction['check_number'] }}</p>
                             @endif
                             <p>Amount {{ $order->formattedAmount }}</p>
                         </div>


### PR DESCRIPTION
Closes #155 
- Allow paid orders to see payment page
- Check if transaction is numeric if doesn't start with hash for check 
- Fix check number in dark mode

Closes #156
- Use `orders`/`reservations` property instead of `rows`

Closes #157 
