### PR TITLE
Fix text in dark mode on auth pages

### DIFF
--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -6,7 +6,7 @@
             </a>
         </x-slot>
 
-        <div class="mb-4 text-sm text-gray-600">
+        <div class="mb-4 text-sm text-gray-600 dark:text-gray-200">
             {{ __('This is a secure area of the application. Please confirm your password before continuing.') }}
         </div>
 

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -2,7 +2,7 @@
     <x-auth.card>
         <x-slot name="logo">
             <a href="/">
-                <x-application-logo class="w-20 h-20 text-gray-500 fill-current" />
+                <x-application-logo class="h-12 text-gray-500 fill-current" />
             </a>
         </x-slot>
 

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -2,7 +2,7 @@
     <x-auth.card>
         <x-slot name="logo">
             <a href="/">
-                <x-application-logo class="w-20 h-20 text-gray-500 fill-current" />
+                <x-application-logo class="h-12 text-gray-500 fill-current" />
             </a>
         </x-slot>
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -2,7 +2,7 @@
     <x-auth.card>
         <x-slot name="logo">
             <a href="/">
-                <x-application-logo class="w-20 h-20 text-gray-500 fill-current" />
+                <x-application-logo class="h-12 text-gray-500 fill-current" />
             </a>
         </x-slot>
 

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -2,7 +2,7 @@
     <x-auth.card>
         <x-slot name="logo">
             <a href="/">
-                <x-application-logo class="w-20 h-20 text-gray-500 fill-current" />
+                <x-application-logo class="h-12 text-gray-500 fill-current" />
             </a>
         </x-slot>
 

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -30,9 +30,9 @@
             <form method="POST" action="{{ route('logout') }}">
                 @csrf
 
-                <button type="submit" class="text-sm text-gray-600 underline hover:text-gray-900">
+                <x-bit.button.flat.primary type="submit" class="ml-3">
                     {{ __('Logout') }}
-                </button>
+                </x-bit.button.flat.primary>
             </form>
         </div>
     </x-auth.card>

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -2,7 +2,7 @@
     <x-auth.card>
         <x-slot name="logo">
             <a href="/">
-                <x-application-logo class="w-20 h-20 text-gray-500 fill-current" />
+                <x-application-logo class="h-12 text-gray-500 fill-current" />
             </a>
         </x-slot>
 

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -6,12 +6,12 @@
             </a>
         </x-slot>
 
-        <div class="mb-4 text-sm text-gray-600">
+        <div class="mb-4 text-sm text-gray-600 dark:text-gray-200">
             {{ __('Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn\'t receive the email, we will gladly send you another.') }}
         </div>
 
         @if (session('status') == 'verification-link-sent')
-            <div class="mb-4 text-sm font-medium text-green-600">
+            <div class="mb-4 text-sm font-medium text-green-600 dark:text-green-200">
                 {{ __('A new verification link has been sent to the email address you provided during registration.') }}
             </div>
         @endif


### PR DESCRIPTION
Fixes bad contrast on the `confirm password` and `verify email` pages in dark mode. It also fixes tiny logos on authentication pages.

<img width="471" alt="Screenshot 2023-05-03 at 5 44 39 PM" src="https://user-images.githubusercontent.com/6541180/236066858-68235333-951e-4a10-b24f-9b71778924b8.png">
<img width="474" alt="Screenshot 2023-05-03 at 5 44 35 PM" src="https://user-images.githubusercontent.com/6541180/236066903-330cb7e6-f894-4969-8add-36cc4e9faebe.png">
