### PR TITLE
Dashboard page for invitations

### DIFF
--- a/app/Livewire/App/Dashboard.php
+++ b/app/Livewire/App/Dashboard.php
@@ -10,7 +10,7 @@ class Dashboard extends Component
 
     public function mount($page = 'orders-reservations')
     {
-        if (auth()->user()->has_invitations) {
+        if (auth()->check() && auth()->user()->has_invitations) {
             $page = 'invitations';
         }
 

--- a/app/Livewire/App/Dashboard.php
+++ b/app/Livewire/App/Dashboard.php
@@ -10,6 +10,10 @@ class Dashboard extends Component
 
     public function mount($page = 'orders-reservations')
     {
+        if (auth()->user()->has_invitations) {
+            $page = 'invitations';
+        }
+
         $this->page = $page;
     }
 

--- a/app/Livewire/App/Dashboard/Invitations.php
+++ b/app/Livewire/App/Dashboard/Invitations.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Livewire\App\Dashboard;
+
+use App\Livewire\Traits\WithFiltering;
+use App\Livewire\Traits\WithSorting;
+use App\Models\Invitation;
+use App\Models\Order;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Invitations extends Component
+{
+    public function render()
+    {
+        return view('livewire.app.dashboard.invitations')
+            ->with([
+                'invitations' => $this->invitations,
+            ]);
+    }
+
+    public function getInvitationsProperty()
+    {
+        return Invitation::where('email', auth()->user()->email)->get();
+    }
+}

--- a/app/Livewire/App/Dashboard/Invitations.php
+++ b/app/Livewire/App/Dashboard/Invitations.php
@@ -16,6 +16,7 @@ class Invitations extends Component
         return view('livewire.app.dashboard.invitations')
             ->with([
                 'invitations' => $this->invitations,
+                'verified' => auth()->user()->hasVerifiedEmail(),
             ]);
     }
 

--- a/app/Livewire/App/Dashboard/Invitations.php
+++ b/app/Livewire/App/Dashboard/Invitations.php
@@ -2,12 +2,8 @@
 
 namespace App\Livewire\App\Dashboard;
 
-use App\Livewire\Traits\WithFiltering;
-use App\Livewire\Traits\WithSorting;
 use App\Models\Invitation;
-use App\Models\Order;
 use Livewire\Component;
-use Livewire\WithPagination;
 
 class Invitations extends Component
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -114,6 +114,11 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
         return $this->pronouns ? "{$this->name} ({$this->pronouns})" : $this->name;
     }
 
+    public function getHasInvitationsAttribute()
+    {
+        return Invitation::where('email', $this->email)->exists();
+    }
+
     // Methods
 
     public function acceptTerms($event)

--- a/config/nav.php
+++ b/config/nav.php
@@ -14,12 +14,4 @@ return [
         ['name' => 'Donations', 'route' => 'galaxy.config.donations', 'icon' => 'heroicon-o-gift', 'roles' => ['institute']],
         ['name' => 'Emails', 'route' => 'galaxy.config.emails', 'icon' => 'heroicon-o-envelope', 'roles' => ['institute']],
     ],
-    'app' => [
-        'dashboard' => [
-            ['name' => 'Event Tickets', 'route' => 'app.dashboard', 'route-param' => 'orders-reservations', 'icon' => 'heroicon-o-calendar'],
-            ['name' => 'Workshop Submissions', 'route' => 'app.dashboard', 'route-param' => 'workshops', 'icon' => 'heroicon-o-light-bulb'],
-            ['name' => 'Donations', 'route' => 'app.dashboard', 'route-param' => 'donations', 'icon' => 'heroicon-o-gift'],
-            ['name' => 'Settings', 'route' => 'app.dashboard', 'route-param' => 'settings', 'icon' => 'heroicon-o-cog'],
-        ],
-    ],
 ];

--- a/resources/views/livewire/app/dashboard.blade.php
+++ b/resources/views/livewire/app/dashboard.blade.php
@@ -1,9 +1,10 @@
 <div class="container px-4 pt-4 pb-12 mx-auto md:py-12 md:px-12">
     <div class="grid grid-cols-1 gap-8 md:grid-cols-4">
         <nav class="space-y-1" aria-label="Sidebar">
-            @foreach (config('nav.app.dashboard') as $link)
-                <x-galaxy.nav-link :href="route($link['route'], $link['route-param'])" :icon="$link['icon']" :active="$link['route-param'] === $page" >{{ $link['name'] }}</x-galaxy.nav-link>
-            @endforeach
+            @if (auth()->user()->has_invitations)
+                <x-galaxy.nav-link :href="route('app.dashboard', 'invitations')" icon="heroicon-o-document" active="'invitations' === $page" >Invitations</x-galaxy.nav-link>
+            @endif
+
             <x-galaxy.nav-link :href="route('app.dashboard', 'orders-reservations')" icon="heroicon-o-calendar" :active="'orders-reservations' === $page" >Event Tickets</x-galaxy.nav-link>
             <x-galaxy.nav-link :href="route('app.dashboard', 'workshops')" icon="heroicon-o-light-bulb" :active="'workshops' === $page" >Workshop Submissions</x-galaxy.nav-link>
             <x-galaxy.nav-link :href="route('app.dashboard', 'donations')" icon="heroicon-o-gift" :active="'donations' === $page" >Donations</x-galaxy.nav-link>
@@ -19,6 +20,8 @@
             <livewire:app.dashboard.donations />
             @elseif ($page === 'settings')
             <livewire:app.dashboard.settings />
+            @elseif ($page === 'invitations')
+            <livewire:app.dashboard.invitations />
             @endif
         </div>
     </div>

--- a/resources/views/livewire/app/dashboard.blade.php
+++ b/resources/views/livewire/app/dashboard.blade.php
@@ -4,6 +4,10 @@
             @foreach (config('nav.app.dashboard') as $link)
                 <x-galaxy.nav-link :href="route($link['route'], $link['route-param'])" :icon="$link['icon']" :active="$link['route-param'] === $page" >{{ $link['name'] }}</x-galaxy.nav-link>
             @endforeach
+            <x-galaxy.nav-link :href="route('app.dashboard', 'orders-reservations')" icon="heroicon-o-calendar" :active="'orders-reservations' === $page" >Event Tickets</x-galaxy.nav-link>
+            <x-galaxy.nav-link :href="route('app.dashboard', 'workshops')" icon="heroicon-o-light-bulb" :active="'workshops' === $page" >Workshop Submissions</x-galaxy.nav-link>
+            <x-galaxy.nav-link :href="route('app.dashboard', 'donations')" icon="heroicon-o-gift" :active="'donations' === $page" >Donations</x-galaxy.nav-link>
+            <x-galaxy.nav-link :href="route('app.dashboard', 'settings')" icon="heroicon-o-cog" :active="'settings' === $page" >Settings</x-galaxy.nav-link>
         </nav>
 
         <div class="col-span-3 text-gray-200">

--- a/resources/views/livewire/app/dashboard/invitations.blade.php
+++ b/resources/views/livewire/app/dashboard/invitations.blade.php
@@ -2,6 +2,13 @@
     <h1 class="text-2xl text-gray-900 dark:text-gray-200">Invitations</h1>
 
     <div class="space-y-8">
+
+        @if (! $verified)
+            <x-ui.alert>
+            You must <a href="{{ route('verification.notice') }}" class="font-bold text-white underline">verify your email</a> before accepting invitations.
+            </x-ui.alert>
+        @endif
+
         @foreach($invitations as $invitation)
         <div class="bg-white dark:bg-gray-800 shadow flex items-center justify-between p-4 space-x-4">
             <div class="flex items-center space-x-4">
@@ -19,7 +26,11 @@
                 </div>
                 @endif
             </div>
-            accept url
+            @if($verified)
+            <x-bit.button.flat.primary :href="$invitation->acceptUrl">Accept Invite</x-bit.button.flat.primary>
+            @else
+            <x-bit.button.flat.primary disabled>Accept Invite</x-bit.button.flat.primary>
+            @endif
         </div>
         @endforeach
     </div>

--- a/resources/views/livewire/app/dashboard/invitations.blade.php
+++ b/resources/views/livewire/app/dashboard/invitations.blade.php
@@ -9,7 +9,7 @@
             </x-ui.alert>
         @endif
 
-        @foreach($invitations as $invitation)
+        @foreach ($invitations as $invitation)
         <div class="bg-white dark:bg-gray-800 shadow flex items-center justify-between p-4 space-x-4">
             <div class="flex items-center space-x-4">
                 @if ($invitation->inviteable_type === App\Models\Ticket::class)
@@ -26,7 +26,7 @@
                 </div>
                 @endif
             </div>
-            @if($verified)
+            @if ($verified)
             <x-bit.button.flat.primary :href="$invitation->acceptUrl">Accept Invite</x-bit.button.flat.primary>
             @else
             <x-bit.button.flat.primary disabled>Accept Invite</x-bit.button.flat.primary>

--- a/resources/views/livewire/app/dashboard/invitations.blade.php
+++ b/resources/views/livewire/app/dashboard/invitations.blade.php
@@ -1,0 +1,26 @@
+<div class="space-y-8">
+    <h1 class="text-2xl text-gray-900 dark:text-gray-200">Invitations</h1>
+
+    <div class="space-y-8">
+        @foreach($invitations as $invitation)
+        <div class="bg-white dark:bg-gray-800 shadow flex items-center justify-between p-4 space-x-4">
+            <div class="flex items-center space-x-4">
+                @if ($invitation->inviteable_type === App\Models\Ticket::class)
+                <x-heroicon-o-ticket class="w-12 h-12 text-gray-500" />
+                <div>
+                    <p class="text-gray-900 dark:text-gray-200">Ticket for {{ $invitation->inviteable->event->name }}</p>
+                    <p class="text-gray-700 dark:text-gray-400">Invited by {{ $invitation->inviter->name }}</p>
+                </div>
+                @elseif ($invitation->inviteable_type === App\Models\Response::class)
+                <x-heroicon-o-light-bulb class="w-12 h-12 text-gray-500"/>
+                <div>
+                    <p class="text-gray-900 dark:text-gray-200">Presenter for {{ $invitation->inviteable->name }}</p>
+                    <p class="text-gray-700 dark:text-gray-400">Invited by {{ $invitation->inviter->name }}</p>
+                </div>
+                @endif
+            </div>
+            accept url
+        </div>
+        @endforeach
+    </div>
+</div>

--- a/tests/Feature/Livewire/App/DashboardTest.php
+++ b/tests/Feature/Livewire/App/DashboardTest.php
@@ -27,14 +27,20 @@ final class DashboardTest extends TestCase
     #[Test]
     public function the_component_can_render(): void
     {
-        Livewire::test(Dashboard::class)
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(Dashboard::class)
             ->assertStatus(200);
     }
 
     #[Test]
     public function by_default_the_page_is_orders_resources()
     {
-        Livewire::test(Dashboard::class)
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(Dashboard::class)
             ->assertSet('page', 'orders-reservations');
     }
 

--- a/tests/Feature/Livewire/App/DashboardTest.php
+++ b/tests/Feature/Livewire/App/DashboardTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature\Livewire\App;
+
+use App\Livewire\App\Dashboard;
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class DashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function happy_path_http_check()
+    {
+        $user = User::factory()->admin()->create();
+
+        $this->actingAs($user)
+            ->get(route('app.dashboard'))
+            ->assertOk();
+    }
+
+    #[Test]
+    public function the_component_can_render(): void
+    {
+        Livewire::test(Dashboard::class)
+            ->assertStatus(200);
+    }
+
+    #[Test]
+    public function by_default_the_page_is_orders_resources()
+    {
+        Livewire::test(Dashboard::class)
+            ->assertSet('page', 'orders-reservations');
+    }
+
+    #[Test]
+    public function if_user_has_invitations_that_becomes_default_page()
+    {
+        $user = User::factory()->create(['email' => 'adora@eternia.gov']);
+        $order = Order::factory()->hasTickets(1)->create();
+        $order->tickets->first()->invite('adora@eternia.gov', $order->user);
+
+        Livewire::actingAs($user)
+            ->test(Dashboard::class)
+            ->assertSet('page', 'invitations');
+    }
+}


### PR DESCRIPTION
- Add a page for user's pending invitations
- Page isn't visible if there are no pending invites
- Sets default page to `invitations` if there are some
- Remove dashboard links from `nav` config
- A invitation cannot be accepted if the user isn't verified