### PR TITLE
Refresh content warnings

### DIFF
--- a/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
+++ b/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\SpatieTagsInput;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -67,6 +68,10 @@ class EventItemsRelationManager extends RelationManager
                     ])
                     ->columns(3)
                     ->hidden(fn (Get $get): bool => $get('parent_id') !== null),
+                SpatieTagsInput::make('tracks')
+                    ->type('tracks'),
+                SpatieTagsInput::make('warnings')
+                    ->type('warnings'),
             ]);
     }
 

--- a/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
+++ b/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
@@ -177,11 +177,16 @@ class EventItemsRelationManager extends RelationManager
 
                             foreach ($items as $item) {
                                 $workshop = Response::find($item->settings->workshop_id);
+
                                 $item->update([
                                     'name' => $workshop->name,
                                     'description' => $workshop->description,
                                     'speaker' => $workshop->collaborators->map(fn ($user) => $user->formattedName)->join(', '),
                                 ]);
+
+                                if (isset($workshop->answers['content-warnings'])) {
+                                    $item->syncTagsWithType($workshop->answers['content-warnings'], 'warnings');
+                                }
                             }
                         }),
                 ])

--- a/resources/views/exports/copyable-schedule.blade.php
+++ b/resources/views/exports/copyable-schedule.blade.php
@@ -15,8 +15,8 @@ Name: {!! htmlspecialchars_decode($child->name) !!}
 Speaker: {{ $child->speaker }}
 Location: {{ $child->location }}
 Description: {!! htmlspecialchars_decode($child->description) !!}
-Track: {{ $item->tracks }}
-Warnings: {{ $item->warnings }}
+Track: {{ $child->tracks }}
+Warnings: {{ $child->warnings }}
 
 @endforeach
 @endif


### PR DESCRIPTION
- Add content warnings to sync action
- Fix `txt` export with child items using the wrong variable
- Add tags input for Tracks and Warnings