### PR TITLE
Cancel orders when canceling presentation

### DIFF
--- a/app/Events/WorkshopStatusChanged.php
+++ b/app/Events/WorkshopStatusChanged.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Response;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WorkshopStatusChanged
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Response $workshop,
+    ) {
+    }
+}

--- a/app/Listeners/CancelWorkshop.php
+++ b/app/Listeners/CancelWorkshop.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\WorkshopStatusChanged;
+use App\Models\Order;
+use App\Notifications\WorkshopCanceled;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Notification;
+
+class CancelWorkshop implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public function handle(WorkshopStatusChanged $event): void
+    {
+        if ($event->workshop->status !== 'canceled') {
+            return;
+        }
+
+        // remove comped orders
+        Order::where('transaction_id', "comped-workshop-{$event->workshop->id}")->delete();
+        Notification::send($event->workshop->collaborators, new WorkshopCanceled($event->workshop));
+
+        // remove invites
+        $event->workshop->invitations->each->delete();
+
+        // @todo notify anyone who signed up for the workshop
+    }
+}

--- a/app/Notifications/WorkshopCanceled.php
+++ b/app/Notifications/WorkshopCanceled.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Response;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class WorkshopCanceled extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Response $workshop)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+                    ->line("We wanted to let you know that {$this->workshop->name} has been canceled")
+                    ->line('Please contact us with any questions.');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,34 +2,28 @@
 
 namespace App\Providers;
 
+use App\Events\WorkshopStatusChanged;
+use App\Listeners\CancelWorkshop;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
 {
-    /**
-     * The event listener mappings for the application.
-     *
-     * @var array
-     */
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
+        WorkshopStatusChanged::class => [
+            CancelWorkshop::class,
+        ],
     ];
 
-    /**
-     * Register any events for your application.
-     */
     public function boot(): void
     {
         // EventBadgeQueue::observe(QueueObserver::class);
     }
 
-    /**
-     * Determine if events and listeners should be automatically discovered.
-     */
     public function shouldDiscoverEvents(): bool
     {
         return false;


### PR DESCRIPTION
When a workshop is canceled:
- delete any associated comped orders 
- delete any pending invitations (why accept an invite to a canceled thing)

Future todos:
- notify anyone who has added that workshop to their schedule
- refactor other workflow type logic to events/listeners