### PR TITLE
Add email that was invited to notifications

### DIFF
--- a/app/Notifications/AcceptInviteReminder.php
+++ b/app/Notifications/AcceptInviteReminder.php
@@ -35,11 +35,13 @@ class AcceptInviteReminder extends Notification implements ShouldQueue
                     ->cc($this->invitation->inviter->email)
                     ->when(get_class($this->model) === Response::class, function ($message) {
                         $message
+                            ->line("This invitation was sent to: {$this->invitation->email}")
                             ->line("This is a reminder that you have a pending invitation to co-present {$this->model->name}.")
                             ->lineIf(in_array($this->model->status, ['confirmed', 'scheduled']), 'It is important to accept the invitation if you plan on presenting. We cannot generate a free ticket for you until the invitation is accepted.');
                     })
                     ->when(get_class($this->model) === Ticket::class, function ($message) {
                         $message
+                            ->line("This invitation was sent to: {$this->invitation->email}")
                             ->line("This is a reminder that you have a pending invitation to attend {$this->model->name}.")
                             ->line('It is important to accept the invitation if you plan on attending, so you can fill out dietary restrictions and accessibility requests.');
                     })

--- a/app/Notifications/AddedAsCollaborator.php
+++ b/app/Notifications/AddedAsCollaborator.php
@@ -26,6 +26,7 @@ class AddedAsCollaborator extends Notification implements ShouldQueue
     {
         return (new MailMessage)
             ->subject('Invited to be co-presenter on ' . $this->response->name)
+            ->line("This invitation was sent to: {$this->invitation->email}")
             ->line('We are letting you know that you have been added as a co-presenter to ' . $this->response->name . '.')
             ->line('You can work on the submission with the other presenters and submit it for review.')
             ->line('If your presentation is accepted, you will have a ticket automatically created for you.')

--- a/app/Notifications/AddedToTicket.php
+++ b/app/Notifications/AddedToTicket.php
@@ -39,7 +39,7 @@ class AddedToTicket extends Notification implements ShouldQueue
 
         return (new MailMessage)
             ->subject('Invited to attend ' . $event)
-            ->line('Hi there,')
+            ->line("This invitation was sent to: {$this->invitation->email}")
             ->line("You have been invited to attend {$event} by {$this->causer}. Click the link below to accept and add your information (e.g. pronouns, accessibility requests) to the ticket.")
             ->action('Accept Invitation', $this->invitation->acceptUrl);
     }

--- a/tests/Unit/Notifications/AcceptInviteReminderTest.php
+++ b/tests/Unit/Notifications/AcceptInviteReminderTest.php
@@ -22,12 +22,12 @@ final class AcceptInviteReminderTest extends TestCase
         $invitation = $response->invite('adora@eternia.gov', $user);
         $notification = (new AcceptInviteReminder($invitation, $response))->toMail($user);
 
-        $this->assertCount(2, $notification->introLines);
+        $this->assertCount(3, $notification->introLines);
 
         $response = Response::factory()->create(['status' => 'work-in-progress']);
         $invitation = $response->invite('adora@eternia.gov', $user);
         $notification = (new AcceptInviteReminder($invitation, $response))->toMail($user);
 
-        $this->assertCount(1, $notification->introLines);
+        $this->assertCount(2, $notification->introLines);
     }
 }


### PR DESCRIPTION
This PR adds a line to all invite accept emails with the email that was invited.