### PR TITLE
Invitation reminder emails

### DIFF
--- a/app/Console/Commands/InvitationReminder.php
+++ b/app/Console/Commands/InvitationReminder.php
@@ -25,6 +25,7 @@ class InvitationReminder extends Command
 
         $invitations->each(function ($invitation) {
             Notification::route('mail', $invitation->email)->notify(new AcceptInviteReminder($invitation));
+            $invitation->touch();
         });
 
         $this->info('Invitation Reminder Complete');

--- a/app/Console/Commands/InvitationReminder.php
+++ b/app/Console/Commands/InvitationReminder.php
@@ -17,7 +17,7 @@ class InvitationReminder extends Command
     {
         $this->info('Running reminder emails to pending invitations...');
 
-        $invitations = Invitation::where('updated_at', '>', now()->subWeek())->all();
+        $invitations = Invitation::where('updated_at', '<=', now()->subWeek())->get();
 
         $this->info($invitations->count() . ' reminders need to be sent.');
 

--- a/app/Console/Commands/InvitationReminder.php
+++ b/app/Console/Commands/InvitationReminder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Invitation;
+use App\Notifications\AcceptInviteReminder;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
+
+class InvitationReminder extends Command
+{
+    protected $signature = 'app:invitation-reminder';
+
+    protected $description = 'Send reminder emails to folks with pending invitations';
+
+    public function handle()
+    {
+        $this->info('Running reminder emails to pending invitations...');
+
+        $invitations = Invitation::where('updated_at', '>', now()->subWeek())->all();
+
+        $this->info($invitations->count() . ' reminders need to be sent.');
+
+        $this->info('Sending notifications...');
+
+        $invitations->each(function ($invitation) {
+            Notification::route('mail', $invitation->email)->notify(new AcceptInviteReminder($invitation));
+        });
+
+        $this->info('Invitation Reminder Complete');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,6 +21,8 @@ class Kernel extends ConsoleKernel
             });
         })->everyFiveMinutes();
 
+        $schedule->command(InvitationReminder::class)->weeklyOn(2, '12:00');
+
         $schedule->command(RunHealthChecksCommand::class)->everyMinute();
     }
 

--- a/app/Filament/Resources/FormResource/RelationManagers/ResponsesRelationManager.php
+++ b/app/Filament/Resources/FormResource/RelationManagers/ResponsesRelationManager.php
@@ -192,7 +192,7 @@ class ResponsesRelationManager extends RelationManager
                         // send out reminder that we can't create order w/ pending invitations
                         $records->filter(fn ($record) => $record->invitations->isNotEmpty())
                             ->each(fn ($proposal) => $proposal->invitations
-                                ->each(fn ($invitation) => Notification::route('mail', $invitation->eamil)
+                                ->each(fn ($invitation) => Notification::route('mail', $invitation->email)
                                     ->notify(new AcceptInviteReminder($invitation, $proposal))));
 
                         Toast::make()

--- a/app/Notifications/AcceptInviteReminder.php
+++ b/app/Notifications/AcceptInviteReminder.php
@@ -21,7 +21,7 @@ class AcceptInviteReminder extends Notification implements ShouldQueue
     public function __construct(Invitation $invitation, $model = null)
     {
         $this->invitation = $invitation;
-        $this->model = ($model === null) ? $invitation->model : $model;
+        $this->model = ($model === null) ? $invitation->inviteable : $model;
     }
 
     public function via(object $notifiable): array

--- a/database/factories/InvitationFactory.php
+++ b/database/factories/InvitationFactory.php
@@ -11,11 +11,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class InvitationFactory extends Factory
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         $response = Response::factory()->create();

--- a/tests/Feature/Commands/InvitationReminderTest.php
+++ b/tests/Feature/Commands/InvitationReminderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use App\Console\Commands\InvitationReminder;
+use App\Models\Invitation;
+use App\Notifications\AcceptInviteReminder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class InvitationReminderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function can_send_reminders_of_pending_invitations()
+    {
+        Notification::fake();
+
+        Invitation::factory()->count(5)->create(['updated_at' => now()->subWeeks(2)]);
+
+        $this->artisan(InvitationReminder::class);
+
+        Notification::assertSentTimes(AcceptInviteReminder::class, 5);
+    }
+}


### PR DESCRIPTION
This PR schedules a weekly command to send the `AcceptInviteReminder` notification to invitations that are a week old.

- Touches the invitation to prevent the reminder getting sent more than once a week
- Fixes a typo in the relationship manager
- Fixes a typo in the notification