### PR TITLE
Redirect to tickets instead of orders

### DIFF
--- a/resources/views/filament/resources/event-resource/widgets/who-needs-what.blade.php
+++ b/resources/views/filament/resources/event-resource/widgets/who-needs-what.blade.php
@@ -24,7 +24,7 @@
                             </button>
                         </td>
                         <td>
-                            <x-filament::link :href="route('filament.admin.resources.orders.view', ['record' => $item->order_id])">
+                            <x-filament::link :href="route('filament.admin.resources.tickets.view', ['record' => $item->id])">
                                 View
                             </x-filament::link>
                         </td>


### PR DESCRIPTION
<img width="622" alt="Screenshot 2023-10-23 at 11 50 14 AM" src="https://github.com/SGDInstitute/enterprise/assets/6541180/b187f34c-51da-4bf7-990d-87b6b4359810">

The view link now redirects to the `tickets.view` page instead of `orders.view`