### PR TITLE
Add more instruction to invite emails

### DIFF
--- a/app/Notifications/AcceptInviteReminder.php
+++ b/app/Notifications/AcceptInviteReminder.php
@@ -35,13 +35,13 @@ class AcceptInviteReminder extends Notification implements ShouldQueue
                     ->cc($this->invitation->inviter->email)
                     ->when(get_class($this->model) === Response::class, function ($message) {
                         $message
-                            ->line("This invitation was sent to: {$this->invitation->email}")
+                            ->line("This invitation was sent to: {$this->invitation->email}. You must use this email address to log in and accept your invitation. It is possible to update your email later.")
                             ->line("This is a reminder that you have a pending invitation to co-present {$this->model->name}.")
                             ->lineIf(in_array($this->model->status, ['confirmed', 'scheduled']), 'It is important to accept the invitation if you plan on presenting. We cannot generate a free ticket for you until the invitation is accepted.');
                     })
                     ->when(get_class($this->model) === Ticket::class, function ($message) {
                         $message
-                            ->line("This invitation was sent to: {$this->invitation->email}")
+                            ->line("This invitation was sent to: {$this->invitation->email}. You must use this email address to log in and accept your invitation. It is possible to update your email later.")
                             ->line("This is a reminder that you have a pending invitation to attend {$this->model->name}.")
                             ->line('It is important to accept the invitation if you plan on attending, so you can fill out dietary restrictions and accessibility requests.');
                     })

--- a/app/Notifications/AddedAsCollaborator.php
+++ b/app/Notifications/AddedAsCollaborator.php
@@ -26,7 +26,7 @@ class AddedAsCollaborator extends Notification implements ShouldQueue
     {
         return (new MailMessage)
             ->subject('Invited to be co-presenter on ' . $this->response->name)
-            ->line("This invitation was sent to: {$this->invitation->email}")
+            ->line("This invitation was sent to: {$this->invitation->email}. You must use this email address to log in and accept your invitation. It is possible to update your email later.")
             ->line('We are letting you know that you have been added as a co-presenter to ' . $this->response->name . '.')
             ->line('You can work on the submission with the other presenters and submit it for review.')
             ->line('If your presentation is accepted, you will have a ticket automatically created for you.')

--- a/app/Notifications/AddedToTicket.php
+++ b/app/Notifications/AddedToTicket.php
@@ -35,7 +35,7 @@ class AddedToTicket extends Notification implements ShouldQueue
 
         return (new MailMessage)
             ->subject('Invited to attend ' . $event)
-            ->line("This invitation was sent to: {$this->invitation->email}")
+            ->line("This invitation was sent to: {$this->invitation->email}. You must use this email address to log in and accept your invitation. It is possible to update your email later.")
             ->line("You have been invited to attend {$event} by {$this->causer}. Click the link below to accept and add your information (e.g. pronouns, accessibility requests) to the ticket.")
             ->action('Accept Invitation', $this->invitation->acceptUrl);
     }


### PR DESCRIPTION
Before

> "This invitation was sent to: {$this->invitation->email}."

After

> "This invitation was sent to: {$this->invitation->email}. You must use this email address to log in and accept your invitation. It is possible to update your email later."

🤞🏻 it helps reduce support emails.