### PR TITLE
Open Checkin

### DIFF
--- a/app/Filament/Resources/EventResource/Pages/EditEvent.php
+++ b/app/Filament/Resources/EventResource/Pages/EditEvent.php
@@ -39,6 +39,15 @@ class EditEvent extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('close-checkin')
+                ->action(function () {
+                    $this->record->settings->allow_checkin = false;
+                    $this->record->save();
+                })
+                ->button()
+                ->color('gray')
+                ->outlined()
+                ->hidden($this->record->start->diffInDays(now()) > 14 || $this->record->settings->allow_checkin !== true),
             Action::make('open-checkin')
                 ->action(function () {
                     $this->record->settings->allow_checkin = true;
@@ -52,8 +61,7 @@ class EditEvent extends EditRecord
                 ->button()
                 ->color('gray')
                 ->outlined()
-                ->disabled($this->record->settings->allow_checkin ?? false)
-                ->hidden($this->record->start->diffInDays(now()) > 14),
+                ->hidden($this->record->start->diffInDays(now()) > 14 || $this->record->settings->allow_checkin === true),
             Action::make('reports')
                 ->url(EventResource::getUrl('report', ['record' => $this->record]))
                 ->button()

--- a/app/Filament/Resources/EventResource/Pages/EditEvent.php
+++ b/app/Filament/Resources/EventResource/Pages/EditEvent.php
@@ -11,6 +11,7 @@ use App\Filament\Resources\EventResource;
 use App\Filament\Resources\EventResource\Widgets\EventMultiWidget;
 use App\Filament\Resources\EventResource\Widgets\StatsOverview;
 use App\Filament\Resources\EventResource\Widgets\TicketBreakdown;
+use App\Notifications\EventCheckIn;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -18,6 +19,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Facades\Notification;
 use Maatwebsite\Excel\Facades\Excel;
 
 class EditEvent extends EditRecord
@@ -37,6 +39,20 @@ class EditEvent extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('open-checkin')
+                ->action(function () {
+                    $this->record->settings->allow_checkin = true;
+                    $this->record->save();
+
+                    Notification::send($this->record->paidInPersonAttendees(), new EventCheckIn($this->record));
+                })
+                ->requiresConfirmation()
+                ->modalHeading('Open Checkin')
+                ->modalDescription('Are you sure you\'d like to open & allow attendees to check-in. This will send a notification to all paid attendees.')
+                ->button()
+                ->color('gray')
+                ->outlined()
+                ->disabled($this->record->settings->allow_checkin),
             Action::make('reports')
                 ->url(EventResource::getUrl('report', ['record' => $this->record]))
                 ->button()

--- a/app/Filament/Resources/EventResource/Pages/EditEvent.php
+++ b/app/Filament/Resources/EventResource/Pages/EditEvent.php
@@ -52,7 +52,8 @@ class EditEvent extends EditRecord
                 ->button()
                 ->color('gray')
                 ->outlined()
-                ->disabled($this->record->settings->allow_checkin),
+                ->disabled($this->record->settings->allow_checkin ?? false)
+                ->hidden($this->record->start->diffInDays(now()) > 14),
             Action::make('reports')
                 ->url(EventResource::getUrl('report', ['record' => $this->record]))
                 ->button()

--- a/app/Filament/Resources/EventResource/Widgets/StatsOverview.php
+++ b/app/Filament/Resources/EventResource/Widgets/StatsOverview.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\EventResource\Widgets;
 
+use App\Models\EventBadgeQueue;
 use App\Models\Order;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -50,6 +51,14 @@ class StatsOverview extends BaseWidget
         return '$' . number_format($this->orders->sum('amount') / 100, 2);
     }
 
+    public function getCheckedInTotalProperty()
+    {
+        return EventBadgeQueue::query()
+            ->join('tickets', 'tickets.id', '=', 'event_badge_queue.ticket_id')
+            ->where('tickets.event_id', $this->record->id)
+            ->count();
+    }
+
     protected function getColumns(): int
     {
         return 2;
@@ -65,6 +74,9 @@ class StatsOverview extends BaseWidget
             Stat::make('Orders', $this->orderTotals),
             Stat::make('Potential Money from Reservations', $this->potentialMoney),
             Stat::make('Money Made from Orders', $this->moneyMade),
+            ...($this->record->settings->allow_checkin
+                ? [Stat::make('Folks Checked In', $this->checkedInTotal)]
+                : []),
         ];
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -179,7 +179,7 @@ class Event extends Model implements HasMedia
 
     public function paidInPersonAttendees()
     {
-        return $this->orders()->paid()->with('tickets.user')->get()
+        return $this->orders()->paid()->with('tickets.user', 'tickets.ticketType')->get()
             ->flatMap->tickets
             ->filter(fn ($ticket) => ! Str::contains($ticket->ticketType->name, ['Virtual', 'virtual']))
             ->filter(fn ($ticket) => $ticket->user_id !== null)

--- a/tests/Feature/Filament/Resources/EventResourceTest.php
+++ b/tests/Feature/Filament/Resources/EventResourceTest.php
@@ -133,7 +133,7 @@ final class EventResourceTest extends TestCase
     }
 
     #[Test]
-    public function checkin_action_is_disabled_when_already_open()
+    public function checkin_action_is_hidden_when_already_open()
     {
         $user = User::factory()->admin()->create();
         $event = Event::factory()->create(['start' => now()->addDay(), 'settings' => ['allow_checkin' => true]]);
@@ -142,6 +142,20 @@ final class EventResourceTest extends TestCase
             ->test(EditEvent::class, [
                 'record' => $event->getRouteKey(),
             ])
-            ->assertActionDisabled('open-checkin');
+            ->assertActionHidden('open-checkin');
+    }
+
+    #[Test]
+    public function can_close_checkin_when_already_open()
+    {
+        $user = User::factory()->admin()->create();
+        $event = Event::factory()->create(['start' => now()->addDay(), 'settings' => ['allow_checkin' => true]]);
+
+        Livewire::actingAs($user)
+            ->test(EditEvent::class, [
+                'record' => $event->getRouteKey(),
+            ])
+            ->callAction('close-checkin')
+            ->assertHasNoActionErrors();
     }
 }

--- a/tests/Feature/Filament/Resources/EventResourceTest.php
+++ b/tests/Feature/Filament/Resources/EventResourceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Filament\Resources;
 
 use App\Filament\Actions\SafeDeleteBulkAction;
 use App\Filament\Resources\EventResource;
+use App\Filament\Resources\EventResource\Pages\EditEvent;
 use App\Filament\Resources\EventResource\RelationManagers\OrdersRelationManager;
 use App\Filament\Resources\EventResource\RelationManagers\ReservationsRelationManager;
 use App\Models\Event;
@@ -12,7 +13,9 @@ use App\Models\Price;
 use App\Models\Ticket;
 use App\Models\TicketType;
 use App\Models\User;
+use App\Notifications\EventCheckIn;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -90,5 +93,29 @@ final class EventResourceTest extends TestCase
             $this->assertNotNull($order->deleted_at);
             $this->assertEmpty($order->tickets);
         }
+    }
+
+    #[Test]
+    public function can_open_registration()
+    {
+        Notification::fake();
+
+        $user = User::factory()->admin()->create();
+        $event = Event::factory()->create();
+        $paidOrder = Order::factory()->for($event)->paid()->create();
+        Ticket::factory()->for($event)->for($paidOrder)->for($user)->create();
+        $unpaidOrder = Order::factory()->for($event)->create();
+        Ticket::factory()->for($event)->for($unpaidOrder)->for(User::factory())->create();
+
+        Livewire::actingAs($user)
+            ->test(EditEvent::class, [
+                'record' => $event->getRouteKey(),
+            ])
+            ->callAction('open-checkin')
+            ->assertHasNoActionErrors();
+
+        $this->assertTrue($event->fresh()->settings->allow_checkin);
+
+        Notification::assertSentTimes(EventCheckIn::class, 1);
     }
 }


### PR DESCRIPTION
This PR adds the ability to open checkin for an event. When clicking the "Open Checkin" action a confirmation modal appears with a notice that users will be notified. If checkin is open, a new widget in the stats area appears showing the current count of folks who are checked in.

<img width="477" alt="Screenshot 2023-10-28 at 11 27 40 PM" src="https://github.com/SGDInstitute/enterprise/assets/6541180/fbf7227d-8b3b-47a7-a0e1-9f30215ea24d">
<img width="409" alt="Screenshot 2023-10-28 at 11 27 28 PM" src="https://github.com/SGDInstitute/enterprise/assets/6541180/d8ad318b-d5c1-4c92-98ba-49c59401f5cb">
