### PR TITLE
Quick Fixes

### DIFF
--- a/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
+++ b/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
@@ -25,7 +25,6 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Notification;
 use Maatwebsite\Excel\Facades\Excel;

--- a/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
+++ b/app/Filament/Resources/EventResource/RelationManagers/EventItemsRelationManager.php
@@ -138,11 +138,7 @@ class EventItemsRelationManager extends RelationManager
                         ->form([
                             Select::make('parent_id')
                                 ->label('Parent')
-                                ->relationship(
-                                    name: 'parent',
-                                    modifyQueryUsing: fn (Builder $query) => $query->whereNull('parent_id')->where('event_id', $this->ownerRecord->id),
-                                )
-                                ->getOptionLabelFromRecordUsing(fn (Model $record) => "{$record->name} ({$record->start->format('D')})")
+                                ->options($this->ownerRecord->items()->whereNull('parent_id')->pluck('name', 'id'))
                                 ->searchable(),
                             Select::make('workshop_id')
                                 ->label('Proposal')

--- a/app/Filament/Resources/FormResource/RelationManagers/ResponsesRelationManager.php
+++ b/app/Filament/Resources/FormResource/RelationManagers/ResponsesRelationManager.php
@@ -41,20 +41,20 @@ class ResponsesRelationManager extends RelationManager
                     ->label('# Reviews')
                     ->sortable()
                     ->toggleable()
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
                 TextColumn::make('reviews_avg_score')
                     ->avg('reviews', 'score')
                     ->label('Avg. Score')
                     ->sortable()
                     ->toggleable()
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
                 IconColumn::make('reviewed')
                     ->label('You Reviewed')
                     ->boolean()
                     ->getStateUsing(fn (Model $record) => $record->reviews->pluck('user_id')->contains(auth()->id()))
                     ->falseIcon('')
                     ->toggleable()
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
                 TextColumn::make('id')
                     ->label('Proposal ID')
                     ->sortable()
@@ -73,12 +73,12 @@ class ResponsesRelationManager extends RelationManager
                     ->formatStateUsing(fn ($state) => $state - 1)
                     ->label('# Co-presenters')
                     ->toggleable()
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
                 TextColumn::make('invitations_count')
                     ->counts('invitations')
                     ->label('# Invitations')
                     ->toggleable()
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
                 TextColumn::make('status')
                     ->sortable()
                     ->action(fn ($livewire, $record) => $livewire->tableFilters['status'] = ['values' => [$record->status]])
@@ -119,7 +119,7 @@ class ResponsesRelationManager extends RelationManager
                         $data['value'] !== null,
                         fn ($query) => $query->where('answers->track-first-choice', $data['value'])
                     ))
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
                 SelectFilter::make('track-second-choice')
                     ->options(
                         fn ($livewire) => collect($livewire->ownerRecord->questions
@@ -134,7 +134,7 @@ class ResponsesRelationManager extends RelationManager
                         $data['value'] !== null,
                         fn ($query) => $query->where('answers->track-second-choice', $data['value'])
                     ))
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
             ], layout: FiltersLayout::AboveContent)
             ->actions([
                 ActionGroup::make([
@@ -214,7 +214,7 @@ class ResponsesRelationManager extends RelationManager
                             ->send();
                     })
                     ->deselectRecordsAfterCompletion()
-                    ->hidden($this->ownerRecord->id !== 35),
+                    ->hidden(! in_array($this->ownerRecord->id, [35, 38])),
             ])
             ->persistFiltersInSession()
             ->persistSortInSession();


### PR DESCRIPTION
- Updates the `parent_id` select field to use an options array instead of a relationship since that was causing a 500
- Updates all instances that were hardcoded to use MBLGTACC 2023's workshop form to also use 2024's 